### PR TITLE
Support starter battery / midpoint auxillary functions.

### DIFF
--- a/custom_components/victron_ble/sensor.py
+++ b/custom_components/victron_ble/sensor.py
@@ -136,6 +136,24 @@ SENSOR_DESCRIPTIONS: Dict[Tuple[SensorDeviceClass, Optional[Units]], Any] = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
     ),
+    (
+        VictronSensor.STARTER_BATTERY_VOLTAGE,
+        Units.ELECTRIC_POTENTIAL_VOLT,
+    ): SensorEntityDescription(
+        key=VictronSensor.STARTER_BATTERY_VOLTAGE,
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    (
+        VictronSensor.MIDPOINT_VOLTAGE,
+        Units.ELECTRIC_POTENTIAL_VOLT,
+    ): SensorEntityDescription(
+        key=VictronSensor.MIDPOINT_VOLTAGE,
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=Units.ELECTRIC_POTENTIAL_VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 }
 
 


### PR DESCRIPTION
If auxiliary monitoring is enabled and configured to "midpoint voltage", or "starter battery voltage", the integration will fail and no entities are created. This patch adds support for these.

This should fix https://github.com/keshavdv/victron-hacs/issues/94 for some users, though its not clear if that was the OP's issue .
