### PR TITLE
Handle case where EXTERNAL_DEVICE_LOAD has a unit

### DIFF
--- a/custom_components/victron_ble/sensor.py
+++ b/custom_components/victron_ble/sensor.py
@@ -96,6 +96,12 @@ SENSOR_DESCRIPTIONS: Dict[Tuple[SensorDeviceClass, Optional[Units]], Any] = {
         native_unit_of_measurement=Units.ELECTRIC_CURRENT_AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    (VictronSensor.EXTERNAL_DEVICE_LOAD, Units.ELECTRIC_CURRENT_AMPERE): SensorEntityDescription(
+        key=VictronSensor.EXTERNAL_DEVICE_LOAD,
+        device_class=SensorDeviceClass.CURRENT,
+        native_unit_of_measurement=Units.ELECTRIC_CURRENT_AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
     (VictronSensor.TIME_REMAINING, Units.TIME_MINUTES): SensorEntityDescription(
         key=VictronSensor.TIME_REMAINING,
         device_class=SensorDeviceClass.DURATION,


### PR DESCRIPTION
Fixes https://github.com/keshavdv/victron-hacs/issues/123 
Alternative to (and based on what I learned from, and would not have been possible without) https://github.com/keshavdv/victron-hacs/issues/101. Thanks @herrfeuer