### PR TITLE
Add VictronBluetooth BLE transport and inverter profile

### DIFF
--- a/custom_components/victron_ble/__init__.py
+++ b/custom_components/victron_ble/__init__.py
@@ -15,10 +15,14 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .device import VictronBluetoothDeviceData
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.SENSOR,
+    Platform.BUTTON,
+    Platform.NUMBER,
+    Platform.SWITCH,
+]
 
 _LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Victron BLE device from a config entry."""

--- a/custom_components/victron_ble/bluetooth.py
+++ b/custom_components/victron_ble/bluetooth.py
@@ -1,0 +1,331 @@
+"""Bluetooth ble helpers and protocol constants for Victron BLE."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional
+
+from bleak import BleakError
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from homeassistant.components.bluetooth import async_ble_device_from_address
+from homeassistant.core import HomeAssistant as ha
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.exceptions import HomeAssistantError as ha_error
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VictronBluetooth:
+    """BLE protocol constants and ble helpers."""
+
+    INIT_UUID = "306b0002-b081-4037-83dc-e59fcc3cdfd0"
+    CMD_INIT = [0xfa, 0x80, 0xff]
+    # command 0xF980 important for receiving notification on uuid 306b0003
+    CMD_INIT_NOTIFY = [0xf9, 0x80]
+
+    # Characteristic UUID (hardcoded in the class)
+    SERVICE_UUID = "306b0003-b081-4037-83dc-e59fcc3cdfd0"
+    # command 0x0303 important for receiving notification
+    CMD_ENABLE_NOTIFY = [0x03, 0x00, 0x03, 0x01, 0x03, 0x03]
+
+    VE_DELIM = 0x19
+    VE_LEN = 0x40
+
+    CMD_VE_REG_GET_STR = [0x05, 0x00, 0x81] + [VE_DELIM]
+    CMD_VE_REG_GET_INT = [0x05, 0x03, 0x81] + [VE_DELIM]
+    CMD_VE_REG_SET     = [0x06, 0x03, 0x82] + [VE_DELIM]
+
+    VE_REG_DEVICE_MODE = 0x0200
+    VE_REG_AC_OUT_VOLTAGE_SETPOINT = 0x0230
+    VE_REG_AC_OUT_VOLTAGE_SETPOINT_MIN = 0x0231
+    VE_REG_AC_OUT_VOLTAGE_SETPOINT_MAX = 0x0232
+
+    VE_REG_HISTORY_TIME = 0x1040
+    VE_REG_HISTORY_ENERGY = 0x1041
+    VE_REG_AC_OUT_CURRENT = 0x2201
+    VE_REG_AC_OUT_VOLTAGE = 0x2200
+    VE_REG_AC_OUT_APPARENT_POWER = 0x2205
+    VE_REG_INV_LOOP_GET_IINV = 0xEB4E
+    VE_REG_DC_CHANNEL1_VOLTAGE = 0xED8D
+    VE_REG_BLUETOOTH_MAC_ADDRESS = 0xEC66
+    VE_REG_BLUETOOTH_ENCRYPTION_KEY = 0xEC65
+
+    REGISTER_SCALE_UNIT: dict[int, dict[str, float | str]] = {
+        VE_REG_AC_OUT_VOLTAGE_SETPOINT:      {"scale": 0.01,  "unit": "V"},
+        VE_REG_AC_OUT_VOLTAGE_SETPOINT_MIN:  {"scale": 0.01,  "unit": "V"},
+        VE_REG_AC_OUT_VOLTAGE_SETPOINT_MAX:  {"scale": 0.01,  "unit": "V"},
+        VE_REG_HISTORY_TIME:                 {"scale": 1.0,   "unit": "s"},
+        VE_REG_HISTORY_ENERGY:               {"scale": 0.01,  "unit": "kVAh"},
+        VE_REG_AC_OUT_CURRENT:               {"scale": 0.1,   "unit": "A"},
+        VE_REG_AC_OUT_VOLTAGE:               {"scale": 0.01,  "unit": "V"},
+        VE_REG_AC_OUT_APPARENT_POWER:        {"scale": 1.0,   "unit": "VA"},
+        VE_REG_INV_LOOP_GET_IINV:            {"scale": 0.001, "unit": "A"},
+        VE_REG_DC_CHANNEL1_VOLTAGE:          {"scale": 0.01,  "unit": "V"},
+    }
+
+    VE_REG_MODE_ON = 0x02
+    VE_REG_MODE_OFF = 0x04
+    VE_REG_MODE_ECO = 0x05
+
+    MODE_TO_REGISTER_VALUE: dict[str, int] = {
+        "on": VE_REG_MODE_ON,
+        "eco": VE_REG_MODE_ECO,
+        "off": VE_REG_MODE_OFF,
+    }
+    VERIFY_TIMEOUT_SECONDS = 20
+
+    RUNTIME_KEY = "victron_ble_runtime"
+    RUNTIME_UPDATED_SIGNAL = "victron_ble_runtime_updated"
+    REQUESTED_REGISTERS: tuple[int, ...] = (
+        VE_REG_DEVICE_MODE,
+        VE_REG_AC_OUT_VOLTAGE_SETPOINT,
+        VE_REG_AC_OUT_VOLTAGE_SETPOINT_MIN,
+        VE_REG_AC_OUT_VOLTAGE_SETPOINT_MAX,
+        VE_REG_INV_LOOP_GET_IINV,
+        VE_REG_HISTORY_TIME,
+        VE_REG_HISTORY_ENERGY,
+    )
+
+    busy_addresses: set[str] = set()
+
+    def __init__(self, hass: ha, address: str) -> None:
+        self.hass = hass
+        self.address = address
+        self.client: Optional[BleakClientWithServiceCache] = None
+        self.register_table: dict[int, dict[str, Any]] = {}
+        self._notify_initialized = False
+
+    def is_connected(self) -> bool:
+        return bool(self.client and self.client.is_connected)
+
+    async def connect(self, timeout: int = 10) -> None:
+        ble_device = async_ble_device_from_address(self.hass, self.address)
+        if ble_device is None:
+            raise ha_error(f"BLE device {self.address} not available")
+        self.client = await establish_connection(
+            BleakClientWithServiceCache,
+            ble_device,
+            self.address,
+            timeout=timeout,
+        )
+        if self.is_connected():
+            for service in self.client.services:
+                for char in service.characteristics:
+                    if "read" in char.properties:
+                        # need to read properties to enable notification later
+                        await self.client.read_gatt_char(char.uuid)
+
+    async def disconnect(self) -> None:
+        try:
+            if self.is_connected():
+                await self.client.disconnect()
+                _LOGGER.debug("Disconnected from %s", self.address)
+            self._notify_initialized = False
+        except Exception as err:
+            _LOGGER.error("Unexpected error with %s: %s", self.address, err)
+
+    async def send_command(self, uuid: str, command: bytes | list[int]) -> bool:
+        if not self.is_connected():
+            _LOGGER.error("Not connected to inverter")
+            return False
+        try:
+            command_bytes = bytes(command)
+            _LOGGER.debug("Sending Command: %s", command_bytes.hex())
+            await asyncio.wait_for(
+                self.client.write_gatt_char(uuid, command_bytes, response=False),
+                timeout=10,
+            )
+            await asyncio.sleep(0.2)
+            return True
+        except Exception as err:
+            _LOGGER.error("Error sending command: %s", err)
+            return False
+
+    async def init_notify(self) -> None:
+        if not self.is_connected():
+            _LOGGER.error("Not connected to inverter")
+            raise ha_error(f"Failed to initialize notifications for {self.address}")
+        if self._notify_initialized:
+            return
+
+        try:
+            _LOGGER.debug("Subscribing to notifications...")
+            await self.client.start_notify(self.SERVICE_UUID, self.notification_handler)
+            await self.send_command(self.INIT_UUID, self.CMD_INIT)
+            await self.send_command(self.INIT_UUID, self.CMD_INIT_NOTIFY)
+            await self.send_command(self.SERVICE_UUID, [0x01])
+            await self.send_command(self.SERVICE_UUID, self.CMD_ENABLE_NOTIFY)
+            self._notify_initialized = True
+
+        except Exception as err:
+            _LOGGER.error("Error during subscribe: %s", err)
+            raise ha_error(f"Failed to initialize notifications for {self.address}")
+
+    async def update_data(self, requested_registers) -> bool:
+        # Force waiting for fresh values from current polling cycle.
+        cmd = []
+        for reg in requested_registers:
+            self.register_table.pop(reg, None)
+            cmd += self.CMD_VE_REG_GET_INT + self.reg_to_bytes(reg)
+
+        try:
+            ok = await self.send_command(self.SERVICE_UUID, cmd)
+            if not ok:
+                return False
+
+            deadline = asyncio.get_running_loop().time() + 10
+            while asyncio.get_running_loop().time() < deadline:
+                missing = [reg for reg in requested_registers if reg not in self.register_table]
+                if not missing:
+                    return True
+                await asyncio.sleep(0.1)
+
+            missing_str = ", ".join(f"0x{reg:04X}" for reg in missing)
+            _LOGGER.debug("Timeout waiting for registers: %s", missing_str)
+            return False
+        except Exception as err:
+            _LOGGER.error("Error sending command: %s", err)
+            return False
+
+    def notification_handler(self, sender: int, data: bytearray) -> None:
+        raw = bytes(data)
+        if len(raw) < 6:
+            return
+        if raw[0] not in (0x08, 0x09):
+            _LOGGER.debug("Notification: %s", data.hex())
+            return
+        if raw[0] == 0x09:
+            return
+
+        value_type = raw[1]
+        delim = raw[2]
+        register = int.from_bytes(raw[3:5], byteorder="big")
+        data_length = raw[5] - self.VE_LEN
+        if delim != self.VE_DELIM or data_length < 0:
+            return
+
+        data_start = 6
+        data_end = data_start + data_length
+        if data_end > len(raw):
+            return
+
+        value_bytes = raw[data_start:data_end]
+        if value_type == 0x00:
+            value: Any = value_bytes.hex()
+            raw_value: Any = value
+            _LOGGER.debug("Notification 0x%04X [str]: %s", register, value)
+        elif value_type == 0x03:
+            raw_value = int.from_bytes(value_bytes, byteorder="little")
+            scale = float(self.REGISTER_SCALE_UNIT.get(register, {}).get("scale", 1.0))
+            value = raw_value * scale
+            _LOGGER.debug("Notification 0x%04X [num]: raw=%s scaled=%s", register, raw_value, value)
+        else:
+            value = value_bytes.hex()
+            raw_value = value
+            _LOGGER.debug("Unhandled value type 0x%02X for register 0x%04X: %s", value_type, register, value)
+
+        self.register_table[register] = {
+            "type": value_type,
+            "raw": value_bytes.hex(),
+            "raw_value": raw_value,
+            "value": value,
+        }
+
+    @staticmethod
+    def reg_to_bytes(register: int) -> list[int]:
+        """Split 16-bit register into high and low byte."""
+        return [(register >> 8) & 0xFF, register & 0xFF]
+
+    @classmethod
+    def runtime_signal(cls, address: str) -> str:
+        return f"{cls.RUNTIME_UPDATED_SIGNAL}_{address}"
+
+    @classmethod
+    def build_set_command(cls, register: int, value: int, value_len: int = 1) -> bytes:
+        if value_len <= 0:
+            raise ValueError("value_len must be positive")
+        payload = value.to_bytes(value_len, byteorder="little", signed=False)
+        return bytes(cls.CMD_VE_REG_SET + cls.reg_to_bytes(register) + [cls.VE_LEN + value_len] + list(payload))
+
+    @classmethod
+    def build_device_mode_command(cls, mode: str) -> bytes:
+        register_value = cls.MODE_TO_REGISTER_VALUE.get(mode)
+        if register_value is None:
+            raise ValueError(f"Unsupported mode: {mode}")
+        return cls.build_set_command(cls.VE_REG_DEVICE_MODE, register_value, value_len=1)
+
+    @classmethod
+    def store_runtime(cls, hass: ha, address: str, register_table: dict[int, dict[str, Any]]) -> None:
+        runtime = hass.data.setdefault(cls.RUNTIME_KEY, {})
+        device_runtime = runtime.setdefault(address, {})
+        device_runtime["register_table"] = dict(register_table)
+        async_dispatcher_send(hass, cls.runtime_signal(address))
+
+    @classmethod
+    async def update(cls, hass: ha, address: str, ble: VictronBluetooth) -> None:
+        await ble.init_notify()
+        if await ble.update_data(cls.REQUESTED_REGISTERS):
+            cls.store_runtime(hass, address, ble.register_table)
+
+    @classmethod
+    async def run(cls, hass: ha, address: str, action: Callable[[VictronBluetooth], Awaitable[None]]) -> None:
+        if address in cls.busy_addresses:
+            raise ha_error(f"Another command for {address} is already in progress")
+        cls.busy_addresses.add(address)
+        _LOGGER.debug("Establishing BLE connection to %s", address)
+        ble = cls(hass, address)
+        try:
+            await ble.connect(timeout=10)
+            _LOGGER.debug("Connected to %s", address)
+            await action(ble)
+        except Exception as err:
+            if isinstance(err, asyncio.TimeoutError):
+                raise ha_error(f"Timeout communicating with {address}")
+            if isinstance(err, BleakError):
+                raise ha_error(f"BLE error with {address}: {err}")
+            raise ha_error(f"Unexpected BLE error with {address}: {err}")
+        finally:
+            await ble.disconnect()
+            cls.busy_addresses.discard(address)
+
+    @classmethod
+    async def execute(cls, hass: ha, address: str, ble: VictronBluetooth, command: bytes | None = None) -> None:
+        if command is not None:
+            ok = await ble.send_command(cls.SERVICE_UUID, command)
+            if not ok:
+                raise ha_error(f"Failed sending command to {address}")
+            _LOGGER.debug("Command sent to %s", address)
+
+        await cls.update(hass, address, ble)
+
+    @classmethod
+    async def async_update(cls, hass: ha, address: str) -> None:
+        async def action(ble: VictronBluetooth) -> None:
+            await cls.execute(hass, address, ble, None)
+        await cls.run(hass, address, action)
+
+    @classmethod
+    async def async_set_mode(cls, hass: ha, address: str, mode: str) -> None:
+        """Build and send a mode command (on/off/eco)."""
+        command = cls.build_device_mode_command(mode)
+        await cls.async_send_command(hass, address, command)
+
+    @classmethod
+    async def async_send_command(cls, hass: ha, address: str, command: bytes) -> None:
+        async def action(ble: VictronBluetooth) -> None:
+            await cls.execute(hass, address, ble, command)
+        await cls.run(hass, address, action)
+
+    @classmethod
+    async def async_setpoint_save(cls, hass: ha, address: str) -> None:
+        """Send BLE command using HA bluetooth stack."""
+        runtime = hass.data.get(cls.RUNTIME_KEY, {})
+        device_runtime = runtime.get(address, {})
+        value = device_runtime.get("pending_setpoint")
+        if not isinstance(value, (int, float)):
+            raise ha_error("Setpoint slider value is not available")
+        scale = float(cls.REGISTER_SCALE_UNIT.get(cls.VE_REG_AC_OUT_VOLTAGE_SETPOINT, {}).get("scale", 1.0))
+        raw_value = int(round(float(value) / scale))
+        command = cls.build_set_command(cls.VE_REG_AC_OUT_VOLTAGE_SETPOINT, raw_value, value_len=2)
+        await cls.async_send_command(hass, address, command)

--- a/custom_components/victron_ble/button.py
+++ b/custom_components/victron_ble/button.py
@@ -1,0 +1,14 @@
+"""Button platform for victron_ble."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .profiles.inverter.button import async_setup_entry as async_setup_inverter_button_entry
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up button entities."""
+    await async_setup_inverter_button_entry(hass, entry, async_add_entities)
+    # await async_setup_charger_button_entry(hass, entry, async_add_entities)
+    # await async_setup_mppt_button_entry(hass, entry, async_add_entities)

--- a/custom_components/victron_ble/config_flow.py
+++ b/custom_components/victron_ble/config_flow.py
@@ -9,6 +9,8 @@ from homeassistant import config_entries
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
+from victron_ble.devices import detect_device_type
+from victron_ble.devices.inverter import Inverter
 
 from .const import DOMAIN
 
@@ -32,13 +34,38 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
     ) -> FlowResult:
         """Handle a flow initialized by bluetooth discovery."""
         _LOGGER.debug(discovery_info)
+
+        is_inverter = self._discovery_is_inverter(discovery_info)
+
         self.context["discovery_info"] = {
             "name": discovery_info.name,
             "address": discovery_info.address,
+            "is_inverter": is_inverter,
         }
+
         await self.async_set_unique_id(discovery_info.address)
         self._abort_if_unique_id_configured()
         return await self.async_step_user()
+
+    def _discovery_is_inverter(
+        self, discovery_info: BluetoothServiceInfoBleak
+    ) -> bool:
+        """Return True when discovered payload parses as InverterData."""
+
+        manufacturer_data = discovery_info.manufacturer_data or {}
+
+        for mfr_id, mfr_data in manufacturer_data.items():
+            if mfr_id != 0x02E1 or not mfr_data.startswith(b"\x10"):
+                continue
+
+            parser = detect_device_type(mfr_data)
+            if not parser:
+                continue
+
+            if parser is Inverter:
+                return True
+
+        return False
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -66,7 +93,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore[call
 
         await self.async_set_unique_id(user_input["address"])
         self._abort_if_unique_id_configured()
-        return self.async_create_entry(title=user_input["name"], data=user_input)
+
+        entry_data = dict(user_input)
+        discovery_info = self.context.get("discovery_info", {})
+        entry_data["is_inverter"] = discovery_info.get("is_inverter", False)
+
+        return self.async_create_entry(title=user_input["name"], data=entry_data)
 
     async def async_step_unignore(self, user_input):
         unique_id = user_input["unique_id"]

--- a/custom_components/victron_ble/number.py
+++ b/custom_components/victron_ble/number.py
@@ -1,0 +1,14 @@
+"""Number platform for victron_ble."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .profiles.inverter.number import async_setup_entry as async_setup_inverter_number_entry
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up number entities."""
+    await async_setup_inverter_number_entry(hass, entry, async_add_entities)
+    # await async_setup_charger_number_entry(hass, entry, async_add_entities)
+    # await async_setup_mppt_number_entry(hass, entry, async_add_entities)

--- a/custom_components/victron_ble/profiles/__init__.py
+++ b/custom_components/victron_ble/profiles/__init__.py
@@ -1,0 +1,1 @@
+"""Device profile packages for victron_ble."""

--- a/custom_components/victron_ble/profiles/inverter/__init__.py
+++ b/custom_components/victron_ble/profiles/inverter/__init__.py
@@ -1,0 +1,1 @@
+"""Inverter device profile for victron_ble."""

--- a/custom_components/victron_ble/profiles/inverter/button.py
+++ b/custom_components/victron_ble/profiles/inverter/button.py
@@ -1,0 +1,159 @@
+"""Button platform for Victron BLE inverter controls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from ...bluetooth import VictronBluetooth
+from ...const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class InverterButtonDescription:
+    """Button description for inverter control."""
+
+    key: str
+    name: str
+    icon: str
+    mode: str | None = None
+    action: str = "set_mode"
+    category: EntityCategory  | None = None
+
+
+BUTTONS: tuple[InverterButtonDescription, ...] = (
+    InverterButtonDescription(
+        key="inverter_on",
+        name="Inverter On",
+        icon="mdi:power-plug",
+        mode="on",
+    ),
+    InverterButtonDescription(
+        key="inverter_eco",
+        name="Inverter Eco",
+        icon="mdi:leaf",
+        mode="eco",
+    ),
+    InverterButtonDescription(
+        key="inverter_off",
+        name="Inverter Off",
+        icon="mdi:power-plug-off",
+        mode="off",
+    ),
+    InverterButtonDescription(
+        key="inverter_update_values",
+        name="Update Values",
+        icon="mdi:refresh",
+        action="update_values",
+        category=EntityCategory.DIAGNOSTIC
+    ),
+    InverterButtonDescription(
+        key="inverter_setpoint_save",
+        name="AC Voltage Apply",
+        icon="mdi:refresh",
+        action="setpoint_save",
+        category=EntityCategory.CONFIG
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up inverter control buttons for inverter devices only."""
+    if not entry.data.get("is_inverter", False):
+        return
+
+    async_add_entities(
+        VictronInverterButtonEntity(hass, entry, description)
+        for description in BUTTONS
+    )
+
+
+class VictronInverterButtonEntity(ButtonEntity):
+    """Button entity that sends BLE inverter commands."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, description: InverterButtonDescription) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._description = description
+        self._attr_name = description.name
+        self._attr_icon = description.icon
+        self._attr_unique_id = f"{entry.unique_id}_{description.key}"
+        if description.category:
+            self._attr_entity_category = description.category
+
+        self._press_lock = asyncio.Lock()
+        self._is_busy = False
+
+    @property
+    def icon(self) -> str:
+        """Return dynamic icon while command is in progress."""
+        if self._is_busy:
+            return "mdi:progress-clock"
+        return self._description.icon
+
+    @property
+    def extra_state_attributes(self) -> dict[str, bool]:
+        """Expose command execution state."""
+        return {"in_progress": self._is_busy}
+
+    @property
+    def available(self) -> bool:
+        """Disable button while command exchange is in progress."""
+        return not self._is_busy
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        address = self._entry.unique_id
+
+        if address:
+            return DeviceInfo(
+                connections={(dr.CONNECTION_BLUETOOTH, address)},
+                name=self._entry.title,
+                manufacturer="Victron",
+            )
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=self._entry.title,
+            manufacturer="Victron",
+        )
+
+    async def async_press(self) -> None:
+        """Handle button press."""
+        if self._press_lock.locked():
+            raise HomeAssistantError("Command is already in progress")
+
+        address = self._entry.unique_id
+
+        if not address:
+            raise ValueError("Missing BLE address in config entry")
+
+        async with self._press_lock:
+            self._is_busy = True
+            self.async_write_ha_state()
+            try:
+                _LOGGER.debug("Sending command '%s' to inverter %s", self._description.key, address)
+                if self._description.action == "set_mode" and self._description.mode:
+                    await VictronBluetooth.async_set_mode(self._hass, address, self._description.mode)
+                elif self._description.action == "update_values":
+                    await VictronBluetooth.async_update(self._hass, address)
+                elif self._description.action == "setpoint_save":
+                    await VictronBluetooth.async_setpoint_save(self._hass, address)
+            finally:
+                self._is_busy = False
+                self.async_write_ha_state()

--- a/custom_components/victron_ble/profiles/inverter/number.py
+++ b/custom_components/victron_ble/profiles/inverter/number.py
@@ -1,0 +1,126 @@
+"""Template number entities for inverter profile."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfElectricPotential
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from ...bluetooth import VictronBluetooth
+from ...const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up inverter template numbers."""
+    if not entry.data.get("is_inverter", False):
+        return
+    async_add_entities([InverterSetpointNumberEntity(entry)])
+
+
+class InverterSetpointNumberEntity(NumberEntity):
+    """AC Voltage slider template (limits wired later)."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_name = "AC Voltage"
+    _attr_native_min_value = 200.0
+    _attr_native_max_value = 245.0
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    _attr_device_class = NumberDeviceClass.VOLTAGE
+    _attr_should_poll = False
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        self._entry = entry
+        self._attr_unique_id = f"{entry.unique_id}_ac_voltage"
+        self._attr_native_value = None
+        self._unsub_dispatcher = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        address = self._entry.unique_id
+        if not address:
+            return
+        self._unsub_dispatcher = async_dispatcher_connect(
+            self.hass,
+            VictronBluetooth.runtime_signal(address),
+            self._handle_runtime_update,
+        )
+        self._refresh_from_runtime()
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub_dispatcher:
+            self._unsub_dispatcher()
+            self._unsub_dispatcher = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_runtime_update(self) -> None:
+        self._refresh_from_runtime()
+        self.async_write_ha_state()
+
+    def _refresh_from_runtime(self) -> None:
+        address = self._entry.unique_id
+        if not address or not self.hass:
+            return
+        runtime = self.hass.data.get(VictronBluetooth.RUNTIME_KEY, {})
+        reg_table = runtime.get(address, {}).get("register_table", {})
+
+        slider_max = None
+        slider_min = None
+        value = None
+
+        row = reg_table.get(VictronBluetooth.VE_REG_AC_OUT_VOLTAGE_SETPOINT)
+        if isinstance(row, dict):
+            value = row.get("value")
+
+        row = reg_table.get(VictronBluetooth.VE_REG_AC_OUT_VOLTAGE_SETPOINT_MIN)
+        if isinstance(row, dict):
+            slider_min = row.get("value")
+
+        row = reg_table.get(VictronBluetooth.VE_REG_AC_OUT_VOLTAGE_SETPOINT_MAX)
+        if isinstance(row, dict):
+            slider_max = row.get("value")
+
+        if isinstance(slider_min, (int, float)):
+            self._attr_native_min_value = float(slider_min)
+        if isinstance(slider_max, (int, float)):
+            self._attr_native_max_value = float(slider_max)
+        if isinstance(value, (int, float)):
+            self._attr_native_value = float(value)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        address = self._entry.unique_id
+        if address:
+            return DeviceInfo(
+                connections={(device_registry.CONNECTION_BLUETOOTH, address)},
+                name=self._entry.title,
+                manufacturer="Victron",
+            )
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=self._entry.title,
+            manufacturer="Victron",
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Template setter; write/apply logic will be added later."""
+        normalized = round(float(value), 2)
+        self._attr_native_value = normalized
+        address = self._entry.unique_id
+        if address and self.hass:
+            runtime = self.hass.data.setdefault(VictronBluetooth.RUNTIME_KEY, {})
+            device_runtime = runtime.setdefault(address, {})
+            device_runtime["pending_setpoint"] = normalized
+        self.async_write_ha_state()

--- a/custom_components/victron_ble/profiles/inverter/sensor.py
+++ b/custom_components/victron_ble/profiles/inverter/sensor.py
@@ -1,0 +1,205 @@
+"""Template diagnostic sensors for inverter profile."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfTime,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers import device_registry
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from ...bluetooth import VictronBluetooth
+from ...const import DOMAIN
+
+
+@dataclass(frozen=True)
+class InverterDiagnosticSensorDescription:
+    """Description for inverter diagnostic sensor template."""
+
+    key: str
+    name: str
+    unit: str | None = None
+    device_class: SensorDeviceClass | None = None
+    state_class: SensorStateClass | None = None
+    options: list[str] | None = None
+    register: int | None = None
+    category: EntityCategory  | None = None
+
+
+SENSOR_DESCRIPTIONS: tuple[InverterDiagnosticSensorDescription, ...] = (
+    InverterDiagnosticSensorDescription(
+        key="ac_voltage_setpoint",
+        name="AC Voltage Setpoint",
+        unit=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=VictronBluetooth.VE_REG_AC_OUT_VOLTAGE_SETPOINT,
+        category=EntityCategory.DIAGNOSTIC
+    ),
+    InverterDiagnosticSensorDescription(
+        key="device_mode",
+        name="Device Mode",
+        device_class=SensorDeviceClass.ENUM,
+        options=["On", "Off", "Eco"],
+        register=VictronBluetooth.VE_REG_DEVICE_MODE,
+        category=EntityCategory.DIAGNOSTIC
+    ),
+    InverterDiagnosticSensorDescription(
+        key="running_time",
+        name="Running Time",
+        unit=UnitOfTime.HOURS,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=VictronBluetooth.VE_REG_HISTORY_TIME,
+        category=EntityCategory.DIAGNOSTIC
+    ),
+    InverterDiagnosticSensorDescription(
+        key="generated_energy",
+        name="Generated enegry",
+        unit="kVAh",
+        state_class=SensorStateClass.MEASUREMENT,
+        register=VictronBluetooth.VE_REG_HISTORY_ENERGY,
+        category=EntityCategory.DIAGNOSTIC
+    ),
+    InverterDiagnosticSensorDescription(
+        key="inverter_loop_current",
+        name="Inverter Loop Current",
+        unit=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        register=VictronBluetooth.VE_REG_INV_LOOP_GET_IINV,
+        category=EntityCategory.DIAGNOSTIC
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up inverter diagnostic template sensors."""
+    if not entry.data.get("is_inverter", False):
+        return
+
+    async_add_entities(
+        InverterDiagnosticSensorEntity(entry, description)
+        for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class InverterDiagnosticSensorEntity(SensorEntity):
+    """Diagnostic inverter sensor template (data binding added later)."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(self, entry: ConfigEntry, description: InverterDiagnosticSensorDescription) -> None:
+        self._entry = entry
+        self._description = description
+        self._unsub_dispatcher = None
+        self._attr_entity_category = description.category
+
+        self.entity_description = SensorEntityDescription(
+            key=description.key,
+            name=description.name,
+            native_unit_of_measurement=description.unit,
+            device_class=description.device_class,
+            state_class=description.state_class,
+            options=description.options,
+        )
+        self._attr_unique_id = f"{entry.unique_id}_{description.key}"
+        self._native_value: Any = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        address = self._entry.unique_id
+        if not address:
+            return
+        self._unsub_dispatcher = async_dispatcher_connect(
+            self.hass,
+            VictronBluetooth.runtime_signal(address),
+            self._handle_runtime_update,
+        )
+        self._refresh_from_runtime()
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub_dispatcher:
+            self._unsub_dispatcher()
+            self._unsub_dispatcher = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_runtime_update(self) -> None:
+        self._refresh_from_runtime()
+        self.async_write_ha_state()
+
+    def _refresh_from_runtime(self) -> None:
+        address = self._entry.unique_id
+        if not address or not self.hass:
+            return
+        runtime = self.hass.data.get(VictronBluetooth.RUNTIME_KEY, {})
+        reg_table = runtime.get(address, {}).get("register_table", {})
+        register = self._description.register
+        if register is None:
+            return
+        row = reg_table.get(register)
+        if not isinstance(row, dict):
+            return
+
+        if register == VictronBluetooth.VE_REG_DEVICE_MODE:
+            raw = row.get("value")
+            mode_map = {
+                VictronBluetooth.VE_REG_MODE_ON: "On",
+                VictronBluetooth.VE_REG_MODE_OFF: "Off",
+                VictronBluetooth.VE_REG_MODE_ECO: "Eco",
+            }
+            self._native_value = mode_map.get(raw)
+            return
+
+        value = row.get("value")
+        if isinstance(value, (int, float)):
+            if register == VictronBluetooth.VE_REG_HISTORY_TIME:
+                self._native_value = round(float(value) / 3600.0, 2)
+            else:
+                self._native_value = value
+
+    @property
+    def native_value(self) -> Any:
+        """Current value placeholder."""
+        return self._native_value
+
+    @property
+    def available(self) -> bool:
+        """Template entities are available, values will be wired later."""
+        return True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        address = self._entry.unique_id
+        if address:
+            return DeviceInfo(
+                connections={(device_registry.CONNECTION_BLUETOOTH, address)},
+                name=self._entry.title,
+                manufacturer="Victron",
+            )
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=self._entry.title,
+            manufacturer="Victron",
+        )

--- a/custom_components/victron_ble/profiles/inverter/switch.py
+++ b/custom_components/victron_ble/profiles/inverter/switch.py
@@ -1,0 +1,156 @@
+"""Switch platform for Victron BLE inverter controls."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import asyncio
+import logging
+from typing import Callable
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from ...bluetooth import VictronBluetooth
+from ...const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+AUTO_UPDATE_INTERVAL = timedelta(minutes=10)
+STARTUP_UPDATE_DELAY_SECONDS = 10.0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up inverter switches for inverter devices only."""
+    if not entry.data.get("is_inverter", False):
+        return
+
+    async_add_entities([InverterAutoUpdateSwitchEntity(hass, entry)])
+
+
+class InverterAutoUpdateSwitchEntity(RestoreEntity, SwitchEntity):
+    """Auto-update switch that polls inverter values periodically."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Auto Update"
+    _attr_icon = "mdi:autorenew"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        self._hass = hass
+        self._entry = entry
+        self._attr_unique_id = f"{entry.unique_id}_auto_update"
+        self._attr_is_on = False
+        self._unsub_interval: Callable[[], None] | None = None
+        self._unsub_startup_update: Callable[[], None] | None = None
+        self._update_lock = asyncio.Lock()
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            _LOGGER.debug("Auto Update restore state is empty for %s", self._entry.unique_id)
+            return
+        if last_state.state == STATE_ON:
+            self._attr_is_on = True
+            self._start_auto_update()
+            self.async_write_ha_state()
+            self._schedule_startup_update()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        address = self._entry.unique_id
+        if address:
+            return DeviceInfo(
+                connections={(dr.CONNECTION_BLUETOOTH, address)},
+                name=self._entry.title,
+                manufacturer="Victron",
+            )
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=self._entry.title,
+            manufacturer="Victron",
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable periodic updates."""
+        if self._attr_is_on:
+            return
+        self._attr_is_on = True
+        self._start_auto_update()
+        self.async_write_ha_state()
+        await self._async_run_update("turn_on")
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable periodic updates."""
+        if not self._attr_is_on:
+            return
+        self._attr_is_on = False
+        self._stop_auto_update()
+        self._cancel_startup_update()
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._stop_auto_update()
+        self._cancel_startup_update()
+        await super().async_will_remove_from_hass()
+
+    def _start_auto_update(self) -> None:
+        if self._unsub_interval is not None:
+            return
+        self._unsub_interval = async_track_time_interval(
+            self._hass,
+            self._handle_interval,
+            AUTO_UPDATE_INTERVAL,
+        )
+
+    def _stop_auto_update(self) -> None:
+        if self._unsub_interval is not None:
+            self._unsub_interval()
+            self._unsub_interval = None
+
+    def _schedule_startup_update(self) -> None:
+        self._cancel_startup_update()
+        self._unsub_startup_update = async_call_later(
+            self._hass,
+            STARTUP_UPDATE_DELAY_SECONDS,
+            self._handle_startup_update,
+        )
+
+    def _cancel_startup_update(self) -> None:
+        if self._unsub_startup_update is not None:
+            self._unsub_startup_update()
+            self._unsub_startup_update = None
+
+    @callback
+    def _handle_interval(self, _now) -> None:
+        if not self._attr_is_on:
+            return
+        self._hass.async_create_task(self._async_run_update("interval"))
+
+    @callback
+    def _handle_startup_update(self, _now) -> None:
+        self._unsub_startup_update = None
+        if not self._attr_is_on:
+            return
+        self._hass.async_create_task(self._async_run_update("restore_delayed"))
+
+    async def _async_run_update(self, source: str) -> None:
+        address = self._entry.unique_id
+        if not address:
+            return
+        async with self._update_lock:
+            try:
+                _LOGGER.debug("Auto update (%s) for inverter %s", source, address)
+                await VictronBluetooth.async_update(self._hass, address)
+            except Exception as err:
+                _LOGGER.error("Auto update failed for inverter %s: %s", address, err)

--- a/custom_components/victron_ble/sensor.py
+++ b/custom_components/victron_ble/sensor.py
@@ -39,6 +39,7 @@ from victron_ble.devices.smart_lithium import BalancerStatus
 
 from .const import DOMAIN
 from .device import VictronSensor
+from .profiles.inverter.sensor import async_setup_entry as async_setup_inverter_sensor_entry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -552,6 +553,9 @@ async def async_setup_entry(
         )
     )
     entry.async_on_unload(coordinator.async_register_processor(processor))
+
+    # Additional inverter-specific diagnostic sensors
+    await async_setup_inverter_sensor_entry(hass, entry, async_add_entities)
 
 
 class VictronBluetoothSensorEntity(

--- a/custom_components/victron_ble/switch.py
+++ b/custom_components/victron_ble/switch.py
@@ -1,0 +1,18 @@
+"""Switch platform for victron_ble."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .profiles.inverter.switch import async_setup_entry as async_setup_inverter_switch_entry
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switch entities."""
+    await async_setup_inverter_switch_entry(hass, entry, async_add_entities)
+    # await async_setup_charger_switch_entry(hass, entry, async_add_entities)
+    # await async_setup_mppt_switch_entry(hass, entry, async_add_entities)


### PR DESCRIPTION
# Add VictronBluetooth BLE transport and inverter profile

## Overview

This PR introduces a new BLE transport and the first device profile for Victron inverter devices, including control, diagnostics, and automatic state polling.

## What was implemented

### BLE Transport

Added a new BLE transport `VictronBluetooth` with logic for:

- device connection and disconnection
- notification initialization
- sending commands to VE registers
- updating data from a register set
- storing runtime data in `hass.data`
- preventing parallel commands per device using `busy_addresses`

### Platform Infrastructure

- Added platform routers and profile infrastructure to support future expansion for other Victron device types.
- Introduced a dedicated `inverter` device profile.

### Inverter Platforms

#### Buttons

- `Inverter On`
- `Inverter Eco`
- `Inverter Off`
- `Update Values`
- `AC Voltage Apply`

#### Number

- `AC Voltage` slider with dynamic `min/max` values retrieved from registers.

#### Sensors

- `AC Voltage Setpoint`
- `Device Mode`
- `Running Time` (`VE_REG_HISTORY_TIME`)
- `Generated Energy` (`VE_REG_HISTORY_ENERGY`)
- `Inverter Loop Current` (`VE_REG_INV_LOOP_GET_IINV`)

Additional inverter diagnostic sensors were also connected to the main `sensor` platform.

#### Switch

`Auto Update` switch implementing:

- periodic polling every **10 minutes**
- state restoration using `RestoreEntity`
- delayed first poll **10 seconds after Home Assistant startup** if the switch was previously `ON`

### Device Discovery

`config_flow` was extended to detect the device type during BLE discovery.

If the advertisement packet is identified as an **Inverter**, the config entry stores:
`is_inverter = True`


## Important: BLE Control Requirements

Before using control or update commands, the device must be **paired and trusted** on the host machine using `bluetoothctl`:

```bash
bluetoothctl
connect <MAC>
trust
pair
```

After running the pair command, enter the device PIN code when prompted.

## Result

An initial inverter profile is now implemented with a full set of control and diagnostic entities, along with an active BLE register command pipeline and automated state polling that restores correctly after Home Assistant restarts.

## Example Screenshot

<img width="822" height="1239" alt="image" src="https://github.com/user-attachments/assets/6183c232-fefa-41dc-8e1b-53ea1a8887c9" />





